### PR TITLE
HALLELUJAH!

### DIFF
--- a/Zenref.Ava/Models/Reference.cs
+++ b/Zenref.Ava/Models/Reference.cs
@@ -147,7 +147,7 @@ namespace Zenref.Ava.Models
         /// <returns></returns>
         public static string DOISearch(string text)
         {
-            string[] textsplit = Regex.Split(text, @"(?:doi: |DOI: |Doi: |doi:)");
+            string[] textsplit = Regex.Split(text, @"(?:doi: |DOI: |Doi: |doi:|doi.org/)");
             string[] result = textsplit[1].Split(" ");
             return result[0];
         }
@@ -239,6 +239,98 @@ namespace Zenref.Ava.Models
         public static List<string> NGramiser(string text)
         {
             return text.Split(' ').ToList();
+        }
+
+        /// <summary>
+        /// Method for manipulating a raw UCN reference string into smaller, but correct pieces the right places.
+        /// This method is not for Antologies or Websites
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static (string Author, string Title, int? YearRef) UCNRefAuthorTitleYearRef(string text)
+        {
+            Reference reference = new();
+            //Last "(?!.*[A-Z+l]\.)" part below takes the last instance in the search
+            string[] TextAuthor = Regex.Split(text, @"(?:[A-Z+l]\.)(?! &)(?! et)(?!.*[A-Z+l]\.)");
+            reference.Author = text.Substring(0, TextAuthor[0].Length + 2);
+
+            //IF THE YEAR DISAPPEARS IT'S BECAUSE I'VE EXCLUDED THE "^" SYMBOL BEFORE THE REGEX STRING!!
+            Match m = Regex.Match(TextAuthor[1], @"^(?: \([0-9]\d{3}\))");
+            if (m.Success)
+            {
+                (string Author, int? YearRef, string Title, string Source) reference1 = CorrectAPACategorizer(text);
+                return (reference1.Author, reference1.Title, reference1.YearRef);
+            }
+            else
+            {
+                string[] TextTitleB = Regex.Split(TextAuthor[1], @"(?:\.)");
+                reference.Title = TextTitleB[0].Substring(1, TextTitleB[0].Length - 1) + ".";
+                //Excludes ISSN and year intervals, remove (?<!-) to undo this.
+                Regex YearExpression = new Regex(@"(?<!-)(?:[1][9][5-9][0-9]|[2][0][0-3][0-9])(?!-)");
+                MatchCollection YearFound = YearExpression.Matches(text);
+                reference.YearRef = Int32.Parse(YearFound[0].Value);
+
+                return (reference.Author, reference.Title, reference.YearRef);
+            }
+        }
+
+        /// <summary>
+        /// Theoretical correct string manipulation APA style
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static (string, int?, string, string) CorrectAPACategorizer(string text)
+        {
+            Reference reference = new();
+            //first case = Correctly inserted reference APA style.
+            string[] TextAuthor = Regex.Split(text, @"(?:\. \(|\.\()");
+
+            reference.Author = TextAuthor[0] + ".";
+            string[] TextYear = Regex.Split(TextAuthor[1], @"(\)(.*))");
+            //or (?:\)) but make sure to unite the string afterwards
+            bool check = Int32.TryParse(TextYear[0], out int Year);
+            if (check)
+            {
+                reference.YearRef = Year;
+            } else 
+            {
+                reference.YearRef = null;
+            }
+            string[] TextTitle = Regex.Split(TextYear[1], @"(?:\. )");
+            reference.Title = TextTitle[1] + ".";
+            reference.Source = TextTitle[2];
+            //Should there be a need for more details a more advanced method needs to be called.
+
+            return (reference.Author, reference.YearRef, reference.Title, reference.Source);
+        }
+        /// <summary>
+        /// Finds the links to the source.
+        /// USE THIS METHOD BEFORE THE OTHER TWO
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static (string?, string?) UCNRefLinks(string text)
+        {
+            Reference reference = new();
+            string[] TextSource = Regex.Split(text, @"(?:https://)|(?:http://)");
+            if (TextSource[1].EndsWith("."))
+            {
+                string TextSourceNoDot = TextSource[1].Substring(0, TextSource[1].Length - 1);
+                reference.Source = TextSourceNoDot;
+            } else
+            {
+                reference.Source = TextSource[1];
+            }
+            
+            if(reference.Source != null)
+            {
+                reference.PubType = "Website";
+            } else
+            {
+                reference.PubType = null;
+            }
+
+            return (reference.PubType, reference.Source);
         }
 
         //Based on Levenshteins distance

--- a/zenref.Tests/ReferenceTest.cs
+++ b/zenref.Tests/ReferenceTest.cs
@@ -1,3 +1,5 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -61,7 +63,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualityOnTwoEqualReferences()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -112,7 +114,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualsReflexsiveProperty()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -140,7 +142,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualsAlsoWorksInReverse()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -163,7 +165,7 @@ namespace zenref.Tests
                 "16-21",
                 "Din far"),
 
-                other = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+                other = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -191,7 +193,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualsWhenOtherIsNullReturnsFalse()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -220,7 +222,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualsTransitive()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -242,7 +244,7 @@ namespace zenref.Tests
                 "20th",
                 "16-21",
                 "Din far"),
-                second = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+                second = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -264,7 +266,7 @@ namespace zenref.Tests
                 "20th",
                 "16-21",
                 "Din far"),
-                third = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+                third = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -298,7 +300,7 @@ namespace zenref.Tests
         [Fact]
         public void ValueEqualsFalseWhenNotEqual()
         {
-            Reference reference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+            Reference reference = new Reference(
                 "Anders Rask",
                 "titel på noget",
                 "bog",
@@ -320,7 +322,7 @@ namespace zenref.Tests
                 "20th",
                 "16-21",
                 "Din far"),
-                notTheSameReference = new Reference(new KeyValuePair<Reference._typeOfId, string>(Reference._typeOfId.Unknown, ""),
+                notTheSameReference = new Reference(
                 "Anders Rask",
                 "Titel på noget andet",
                 "bog",
@@ -370,6 +372,73 @@ namespace zenref.Tests
 
             //Assert
             Assert.Equal(0.5, Result);
+        }
+
+        [Fact]
+        public void RegexWebsiteRef()
+        {
+            //Arrange
+            string text = "Sundhedsstyrelsen.Danskernes sundhed - Den nationale sundhedsprofil 2017[Internet]. [Kbh.]: Sundhedsstyrelsen; 2018. 131 p. [cited 2019 Oct 22].Available from: https://www.sst.dk/da/udgivelser/2018/danskernes-sundhed-den-nationale-sundhedsprofil-2017.";
+            (string? PubType, string? Source) Expected = new();
+            Expected.PubType = "Website";
+            Expected.Source = "www.sst.dk/da/udgivelser/2018/danskernes-sundhed-den-nationale-sundhedsprofil-2017";
+            //Act
+            (string?, string?) Actual = Reference.UCNRefLinks(text);
+
+            //Assert
+            Assert.Equal(Expected, Actual);
+        }
+
+        [Fact]
+        public void RegexPoorRef()
+        {
+            //Arrange
+            string text = "Rasmussen K, Kampmann J, Warming H. Interview med børn. 1. udgave. Kbh.: Hans Rit-zels Forlag A/S; 2017. 240 s.";
+            (string Author, string Title, int? YearRef) Expected = new();
+            Expected.Author = "Rasmussen K, Kampmann J, Warming H.";
+            Expected.Title = "Interview med børn.";
+            Expected.YearRef = 2017;
+
+            //Act
+            (string, string, int?) Actual = Reference.UCNRefAuthorTitleYearRef(text);
+
+            //Assert
+            Assert.Equal(Expected, Actual);
+        }
+
+        [Fact]
+        public void RegexCorrectAPAStyleRef()
+        {
+            //Arrange
+            string text = "Austring, B. D. & Sørensen, M. (2006). Æstetik og læring: Grundbog om æstetiske læreprocesser. København: Hans Reitzels Forlag.";
+            (string Author, int? YearRef, string Title, string Source) Expected = new ();
+            Expected.Author = "Austring, B. D. & Sørensen, M.";
+            Expected.YearRef = 2006;
+            Expected.Title = "Æstetik og læring: Grundbog om æstetiske læreprocesser.";
+            Expected.Source = "København: Hans Reitzels Forlag.";
+
+            //Act
+            (string, int?, string, string) Actual = Reference.CorrectAPACategorizer(text);
+
+            //Assert
+            Assert.Equal(Expected, Actual);
+        }
+
+        [Fact]
+        public void MethodInsideRegexUCNRef()
+        {
+            //Arrange
+            string text = "Andersen, F. B. (2000). Tegn er noget vi bestemmer: Evalerung, hvalitet og udviklinger i omegnen af SMTTE-tænkningen. Aarhus: Danmarks Lærerhøjskole.";
+            (string Author, string Title, int? YearRef) Expected = new();
+            Expected.Author = "Andersen, F. B.";
+            Expected.Title = "Tegn er noget vi bestemmer: Evalerung, hvalitet og udviklinger i omegnen af SMTTE-tænkningen.";
+            Expected.YearRef = 2000;
+
+            //Act
+            (string, string, int?) Actual = Reference.UCNRefAuthorTitleYearRef(text);
+
+            //Assert
+            Assert.Equal(Expected, Actual);
         }
     }
 }


### PR DESCRIPTION
My prayers have been heard! 
- Regex for poor references, website references, and correct apa ref are complete.
 - Antologies will not function in these, as I cannot fathom a pattern between correct and ucn students ways.
- Lots of ways to refactor should the urge arise :D
- Always check for the search string "[Internet]" before anything else in order to separate references between credible and well... website references.
- referencetests are poor as I only test one instance of references and a theory should be used instead, but maaan, VS got mad at me when i tried that.
- Anyways. Shit works to some extend. remember to apply Fastenshtein to correct for any marginal errors in the texts.

- Happy Hanukkah people <3